### PR TITLE
Distance the lower the better

### DIFF
--- a/tkge/models/loss/MarginRankingLoss.py
+++ b/tkge/models/loss/MarginRankingLoss.py
@@ -1,4 +1,5 @@
 from tkge.models.loss import Loss
+from tkge.models.model import BaseModel
 
 import torch
 
@@ -8,6 +9,7 @@ class MarginRankingLoss(Loss):
     def __init__(self, config):
         super().__init__(config)
 
+        self.model = self.config.get("model.name")
         self.margin = self.config.get("train.loss.margin")
         self.reduction = self.config.get("train.loss.reduction")
 
@@ -30,7 +32,9 @@ class MarginRankingLoss(Loss):
 
         positive_scores = positive_scores.repeat((ns, 1)).squeeze()
         negative_scores = negative_scores.reshape(-1)
-        y = torch.ones_like(positive_scores)
+
+        # use -1 as target/y if a translation based model is used, else 1
+        y = torch.neg(torch.ones_like(positive_scores)) if self.model in ["atise", "ta_transe", "ttranse"] else torch.ones_like(positive_scores)
 
         return self._loss(positive_scores, negative_scores, y)
 

--- a/tkge/models/loss/MarginRankingLoss.py
+++ b/tkge/models/loss/MarginRankingLoss.py
@@ -8,7 +8,6 @@ class MarginRankingLoss(Loss):
     def __init__(self, config):
         super().__init__(config)
 
-        self.model = self.config.get("model.name")
         self.margin = self.config.get("train.loss.margin")
         self.reduction = self.config.get("train.loss.reduction")
 
@@ -32,8 +31,7 @@ class MarginRankingLoss(Loss):
         positive_scores = positive_scores.repeat((ns, 1)).squeeze()
         negative_scores = negative_scores.reshape(-1)
 
-        # use -1 as target/y if a translation based model is used, else 1
-        y = torch.neg(torch.ones_like(positive_scores)) if self.model in ["atise", "ta_transe", "ttranse"] else torch.ones_like(positive_scores)
+        y = torch.ones_like(positive_scores)
 
         return self._loss(positive_scores, negative_scores, y)
 

--- a/tkge/models/loss/MarginRankingLoss.py
+++ b/tkge/models/loss/MarginRankingLoss.py
@@ -1,5 +1,4 @@
 from tkge.models.loss import Loss
-from tkge.models.model import BaseModel
 
 import torch
 

--- a/tkge/models/model.py
+++ b/tkge/models/model.py
@@ -389,6 +389,10 @@ class HyTEModel(BaseModel):
     def __init__(self, config: Config, dataset: DatasetProcessor):
         super().__init__(config, dataset)
 
+    def forward(self, samples: torch.Tensor, **kwargs):
+        # TODO remember to negate the scores with torch.neg(scores)
+        raise NotImplementedError
+
 
 @BaseModel.register(name="atise")
 class ATiSEModel(BaseModel):
@@ -618,9 +622,9 @@ class TATransEModel(BaseModel):
         rseq_e = self.dropout(rseq_e)
 
         if self.l1_flag:
-            scores = torch.sum(torch.abs(h_e + rseq_e - t_e), 1)
+            scores = torch.neg(torch.sum(torch.abs(h_e + rseq_e - t_e), 1))
         else:
-            scores = torch.sum((h_e + rseq_e - t_e) ** 2, 1)
+            scores = torch.neg(torch.sum((h_e + rseq_e - t_e) ** 2, 1))
 
         factors = {
             "norm": (h_e,
@@ -789,9 +793,9 @@ class TTransEModel(BaseModel):
         tem_e = self.embedding['tem'](tem)
 
         if self.l1_flag:
-            scores = torch.sum(torch.abs(h_e + r_e + tem_e - t_e), dim=1)
+            scores = torch.neg(torch.sum(torch.abs(h_e + r_e + tem_e - t_e), dim=1))
         else:
-            scores = torch.sum((h_e + r_e + tem_e - t_e) ** 2, dim=1)
+            scores = torch.neg(torch.sum((h_e + r_e + tem_e - t_e) ** 2, dim=1))
 
         factors = {
             "norm": (h_e,


### PR DESCRIPTION
Now the implementation should fit the assumption that there's a big distance (i.e. a small negative value for the negative samples) between h+r+temp and t of negative samples and vice versa (i.e. a big negative value for the positive samples) a small/zero distance between h+r+temp and t of positive samples.

So the "small negative value for the negative samples" indicates a bigger distance than the "big negative value for the positive samples". That's what we want. Before it was confusing because the bigger values of the positive samples have twisted the distance assumption. 

Of course, this implementation is only used for the distance/translation based models, namely TATransE, TTranse and HyTE. Note that I confused HyTE with ATiSE in the commit messages by accident.