### PR TITLE
main in trainer.py needs to check if a lr_scheduler was initialized b…

### DIFF
--- a/tkge/task/trainer.py
+++ b/tkge/task/trainer.py
@@ -211,7 +211,7 @@ class TrainTask(Task):
             stop = time.time()
             avg_loss = total_loss / train_size
 
-            if not self.lr_scheduler:
+            if self.lr_scheduler:
                 if isinstance(self.lr_scheduler, torch.optim.lr_scheduler.ReduceLROnPlateau):
                     self.lr_scheduler.step(avg_loss)
                 else:


### PR DESCRIPTION
I think there was a little bug in the main in trainer.py regarding the lr_scheduler. It checked if the lr_scheduler does not exist to continue with its step, but this will always raise an AttributeError if no lr_scheduler is used. 