### PR TITLE
Advanced log and ckpt management

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,35 +41,58 @@ This is an example of how you may give instructions on setting up your project l
 To get a local copy up and running follow these simple example steps.
 
 ### Prerequisites
-
 * python3
 * pytorch
 * pyyaml
 * numba
 * arrow
 
-
-
-
 ### Installation
-
-1. git clone the repo to your local derictory
-
-
+1. Set up your python environment with e.g. [conda](https://conda.io/projects/conda/en/latest/user-guide/getting-started.html) (see prerequisites).
+2. Clone the repo to your local directory via `git clone https://github.com/TemporalKGTeam/tkg-framework.git` or download the zip.
 
 <!-- USAGE EXAMPLES -->
 ## Usage
 
+### Run options
+There are 4 different options to run the tkg-framework:
+1. Training of a model
+2. Resumption of training of a model
+3. Evaluation of a trained model
+4. Search of an appropriate hyperparameter setting for a model
  ```
- # test a model
+ # 1. & 2. train a model
  python tkge.py train --config config-default.yaml
 
- # eval a model
+ # 3. evaluate a model
  python tkge.py eval --config config-default.yaml
+ 
+ # 4. search for appropriate setting of a model
+ python tkge.py search --config config-default.yaml
  ```
 
-
-
+### Execution environment
+You just need to specify an execution directory in the config file where all the checkpoints and logfiles of the executions will be maintained automatically.<br>
+If you do not specify any directory in the config file, the execution directory tkg-framework/execution/ will be created automatically inside the tkg-framework directory.<br>
+In the config file:
+```
+# maintain checkpoints and logfiles in a specified directory
+console:
+  execution_dir: path/to/directory
+  
+# maintain checkpoints and logfiles in the default directory (i.e. tkg-framework/execution)
+console:
+  execution_dir: ~
+```
+If you execute a train task with a given configuration for the first time, you'll find the results in:<br><br>
+`path/to/<execution_directory>/<execution-type>/<model-type>/<execution-id>/log`
+`path/to/<execution_directory>/<execution-type>/<model-type>/<execution-id>/ckpt`
+- `<execution-directory>` is the specified (or default) execution directory.
+- `<execution-type>` is the specified task (train, eval, search).
+- `<model-type>` is the specified model type/name (e.g. ttranse).
+- `<execution-id>` is a unique id for the execution. This can be used to resume the training for a model with the same configuration.
+- `log` maintains the logfiles identified by the start timestamp of the execution (useful for training resumption so one can differ between the different executions).
+- `ckpt` maintains the checkpoints of a model identified by the epoch number.
 
 <!-- LICENSE -->
 ## License

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ console:
   execution_dir: ~
 ```
 If you execute a train task with a given configuration for the first time, you'll find the results in:<br><br>
-`path/to/<execution_directory>/<execution-type>/<model-type>/<execution-id>/log`
+`path/to/<execution_directory>/<execution-type>/<model-type>/<execution-id>/log`<br>
 `path/to/<execution_directory>/<execution-type>/<model-type>/<execution-id>/ckpt`
 - `<execution-directory>` is the specified (or default) execution directory.
 - `<execution-type>` is the specified task (train, eval, search).

--- a/tkge/common/config.py
+++ b/tkge/common/config.py
@@ -201,11 +201,11 @@ class Config:
                           "info": 1,
                           "warning": 2,
                           "error": 3}
+                line = f"{level.upper()}: {line}"
                 if levels.get(level) >= levels.get(self.log_level):
-                    line = f"{level.upper()}: {line}"
-                if self.echo:
-                    print(line)
-                file.write(f"{str(datetime.datetime.now())} {line}\n")
+                    if self.echo:
+                        print(line)
+                    file.write(f"{str(datetime.datetime.now())} {line}\n")
 
     def trace(
             self, echo=False, echo_prefix="", echo_flow=False, log=False, **kwargs

--- a/tkge/common/config.py
+++ b/tkge/common/config.py
@@ -26,6 +26,7 @@ class Config:
     def __init__(self, options: Dict[str, Any]):
         self.options = options
 
+        self.file = self.get("file")
         self.folder = self.get("train.checkpoint.folder")  # main folder (config file, checkpoints, ...)
         self.log_folder = self.get("console.folder")  # None means use self.folder; used for kge.log, trace.yaml
         self.log_prefix: str = None
@@ -34,6 +35,8 @@ class Config:
     def create_from_yaml(cls, filepath: str):
         with open(filepath, "r") as file:
             options: Dict[str, Any] = yaml.load(file, Loader=yaml.SafeLoader)
+
+        options["file"] = filepath
 
         return cls(options=options)
 
@@ -332,7 +335,7 @@ class Config:
         """
         model = self.get("model.type")
         dataset = self.get("dataset.name")
-        config = self.folder[:-5]
+        config = self.file[:-5]
 
         epoch_prefix = f"epoch_{epoch}_"
         config_name = f"model_{model}_dataset_{dataset}_config_{config}"

--- a/tkge/common/config.py
+++ b/tkge/common/config.py
@@ -35,6 +35,8 @@ class Config:
                                         self.config_file[:-5], "exec-" + str(self.execution_id), "ckpt")
         self.start_time = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
         self.log_file = os.path.join(self.log_folder, f"{self.start_time}.log")
+        self.log_level = self.get("console.log_level")
+        self.echo = self.get("console.echo")
 
     @classmethod
     def create_from_yaml(cls, filepath: str):
@@ -182,7 +184,7 @@ class Config:
                 result[fullkey] = value
 
     # Logging and Tracing
-    def log(self, msg: str, echo=True, prefix=""):
+    def log(self, msg: str, level="info"):
         """Add a message to the default log file.
 
         Optionally also print on console. ``prefix`` is used to indent each
@@ -194,11 +196,15 @@ class Config:
 
         with open(self.log_file, "a") as file:
             for line in msg.splitlines():
-                if prefix:
-                    line = prefix + line
-                if echo:
+                levels = {"debug": 0,
+                          "info": 1,
+                          "warning": 2,
+                          "error": 3}
+                if levels.get(self.log_level) >= levels.get(level):
+                    line = f"{level.upper()}: {line}"
+                if self.echo:
                     print(line)
-                file.write(str(datetime.datetime.now()) + " " + line + "\n")
+                file.write(f"{str(datetime.datetime.now())} {line}\n")
 
     def trace(
             self, echo=False, echo_prefix="", echo_flow=False, log=False, **kwargs

--- a/tkge/common/config.py
+++ b/tkge/common/config.py
@@ -6,6 +6,7 @@ import os
 import sys
 import re
 from enum import Enum
+from datetime import datetime
 import datetime
 import time
 import uuid
@@ -30,6 +31,7 @@ class Config:
         self.folder = self.get("train.checkpoint.folder")  # main folder (config file, checkpoints, ...)
         self.log_folder = self.get("console.folder")  # None means use self.folder; used for kge.log, trace.yaml
         self.log_prefix: str = None
+        self.start_time = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
 
     @classmethod
     def create_from_yaml(cls, filepath: str):
@@ -318,12 +320,12 @@ class Config:
         return value
 
     def logdir(self) -> str:
-        folder = self.log_folder if self.log_folder else self.folder
+        overall_folder = self.log_folder if self.log_folder else self.folder
+        folder = os.path.join(overall_folder, self.get("model.type"))
         return folder
 
     def logfile(self) -> str:
-        folder = self.log_folder if self.log_folder else self.folder
-        return os.path.join(folder, "kge.log")
+        return os.path.join(self.logdir(), f"{self.train_config_name(epoch=0)}_started_{self.start_time}.log")
 
     def tracefile(self) -> str:
         folder = self.log_folder if self.log_folder else self.folder

--- a/tkge/common/config.py
+++ b/tkge/common/config.py
@@ -6,7 +6,6 @@ import os
 import sys
 import re
 from enum import Enum
-from datetime import datetime
 import datetime
 import time
 import uuid

--- a/tkge/common/config.py
+++ b/tkge/common/config.py
@@ -201,7 +201,7 @@ class Config:
                           "info": 1,
                           "warning": 2,
                           "error": 3}
-                if levels.get(self.log_level) >= levels.get(level):
+                if levels.get(level) >= levels.get(self.log_level):
                     line = f"{level.upper()}: {line}"
                 if self.echo:
                     print(line)

--- a/tkge/common/config.py
+++ b/tkge/common/config.py
@@ -185,7 +185,8 @@ class Config:
 
     # Logging and Tracing
     def log(self, msg: str, level="info"):
-        """Add a message to the default log file.
+        """
+        Add a message to the default log file.
 
         Optionally also print on console. ``prefix`` is used to indent each
         output line.
@@ -209,7 +210,8 @@ class Config:
     def trace(
             self, echo=False, echo_prefix="", echo_flow=False, log=False, **kwargs
     ) -> Dict[str, Any]:
-        """Write a set of key-value pairs to the trace file.
+        """
+        Write a set of key-value pairs to the trace file.
 
         The pairs are written as a single-line YAML record. Optionally, also
         echo to console and/or write to log file.
@@ -224,7 +226,7 @@ class Config:
         if echo or log:
             msg = yaml.dump(kwargs, default_flow_style=echo_flow)
             if log:
-                self.log(msg, echo, echo_prefix)
+                self.log(msg)
             else:
                 for line in msg.splitlines():
                     if echo_prefix:

--- a/tkge/common/config.py
+++ b/tkge/common/config.py
@@ -326,6 +326,19 @@ class Config:
         folder = self.log_folder if self.log_folder else self.folder
         return os.path.join(folder, "trace.yaml")
 
+    def train_config_name(self, epoch=0) -> str:
+        """
+        Returns an unique config name with the epoch prefix if epoch is given greater than 0.
+        """
+        model = self.get("model.type")
+        dataset = self.get("dataset.name")
+        config = self.folder[:-5]
+
+        epoch_prefix = f"epoch_{epoch}_"
+        config_name = f"model_{model}_dataset_{dataset}_config_{config}"
+
+        return epoch_prefix + config_name if epoch > 0 else config_name
+
 
 # class Config:
 #     """

--- a/tkge/task/trainer.py
+++ b/tkge/task/trainer.py
@@ -308,21 +308,30 @@ class TrainTask(Task):
         raise NotImplementedError
 
     def save_ckpt(self, epoch):
-        model = self.config.get("model.name")
-        dataset = self.config.get("dataset.name")
-        folder = self.config.get("train.checkpoint.folder")
-        filename = f"epoch_{epoch}_model_{model}_dataset_{dataset}.ckpt"
+        overall_ckpt_folder = self.config.get("train.checkpoint.folder")
+        ckpt_folder = os.path.join(overall_ckpt_folder, self.config.get("model.name"))
+        filename = f"{self.config.train_config_name(epoch)}.ckpt"
 
-        self.config.log(f"Save the model to {folder} as file {filename}")
+        self.config.log(f"Save the model to {ckpt_folder} as file {filename}")
 
-        checkpoint = {
-            'last_epoch': epoch,
-            'state_dict': self.model.state_dict(),
-            'optimizer': self.optimizer.state_dict(),
-            'lr_scheduler': self.lr_scheduler.state_dict()
-        }
+        if self.lr_scheduler:
+            checkpoint = {
+                'last_epoch': epoch,
+                'state_dict': self.model.state_dict(),
+                'optimizer': self.optimizer.state_dict(),
+                'lr_scheduler': self.lr_scheduler.state_dict()
+            }
+        else:
+            checkpoint = {
+                'last_epoch': epoch,
+                'state_dict': self.model.state_dict(),
+                'optimizer': self.optimizer.state_dict()
+            }
 
-        torch.save(checkpoint, os.path.join(folder, filename))  # os.path.join(model, dataset, folder, filename))
+        if not os.path.exists(ckpt_folder):
+            os.makedirs(ckpt_folder, 0o700)
+
+        torch.save(checkpoint, os.path.join(ckpt_folder, filename))  # os.path.join(model, dataset, folder, filename))
 
     def load_ckpt(self, ckpt_path):
         raise NotImplementedError

--- a/tkge/task/trainer.py
+++ b/tkge/task/trainer.py
@@ -218,6 +218,8 @@ class TrainTask(Task):
                     self.lr_scheduler.step()
 
             self.config.log(f"Loss in iteration {epoch} : {avg_loss} consuming {stop - start}s")
+            self.config.log(f"Warning test message", level="warning")
+            self.config.log(f"Error test message", level="error")
 
             if epoch % save_freq == 0:
                 self.save_ckpt(epoch)

--- a/tkge/task/trainer.py
+++ b/tkge/task/trainer.py
@@ -211,7 +211,7 @@ class TrainTask(Task):
             stop = time.time()
             avg_loss = total_loss / train_size
 
-            if not self.lr_scheduler:
+            if self.lr_scheduler:
                 if isinstance(self.lr_scheduler, torch.optim.lr_scheduler.ReduceLROnPlateau):
                     self.lr_scheduler.step(avg_loss)
                 else:
@@ -309,7 +309,7 @@ class TrainTask(Task):
 
     def save_ckpt(self, epoch):
         overall_ckpt_folder = self.config.get("train.checkpoint.folder")
-        ckpt_folder = os.path.join(overall_ckpt_folder, self.config.get("model.name"))
+        ckpt_folder = os.path.join(overall_ckpt_folder, self.config.get("model.type"))
         filename = f"{self.config.train_config_name(epoch)}.ckpt"
 
         self.config.log(f"Save the model to {ckpt_folder} as file {filename}")

--- a/tkge/task/trainer.py
+++ b/tkge/task/trainer.py
@@ -220,6 +220,7 @@ class TrainTask(Task):
             self.config.log(f"Loss in iteration {epoch} : {avg_loss} consuming {stop - start}s")
             self.config.log(f"Warning test message", level="warning")
             self.config.log(f"Error test message", level="error")
+            self.config.log(f"Debug test message should not be shown", level="debug")
 
             if epoch % save_freq == 0:
                 self.save_ckpt(epoch)

--- a/tkge/task/trainer.py
+++ b/tkge/task/trainer.py
@@ -218,9 +218,6 @@ class TrainTask(Task):
                     self.lr_scheduler.step()
 
             self.config.log(f"Loss in iteration {epoch} : {avg_loss} consuming {stop - start}s")
-            self.config.log(f"Warning test message", level="warning")
-            self.config.log(f"Error test message", level="error")
-            self.config.log(f"Debug test message should not be shown", level="debug")
 
             if epoch % save_freq == 0:
                 self.save_ckpt(epoch)

--- a/tkge/task/trainer.py
+++ b/tkge/task/trainer.py
@@ -123,7 +123,7 @@ class TrainTask(Task):
             scheduler_args = self.config.get("train.lr_scheduler.args")
             self.lr_scheduler = get_scheduler(self.optimizer, scheduler_type, scheduler_args)
 
-        self.config.log((f"Initializeing regularizer"))
+        self.config.log(f"Initializeing regularizer")
         self.regularizer = dict()
         self.inplace_regularizer = dict()
 
@@ -139,7 +139,7 @@ class TrainTask(Task):
         self.evaluation = Evaluation(config=self.config, dataset=self.dataset)
 
     def main(self):
-        self.config.log("BEGIN TRANING")
+        self.config.log("BEGIN TRAINING")
 
         save_freq = self.config.get("train.checkpoint.every")
         eval_freq = self.config.get("train.valid.every")
@@ -217,7 +217,7 @@ class TrainTask(Task):
                 else:
                     self.lr_scheduler.step()
 
-            self.config.log(f"Loss in iteration {epoch} : {avg_loss} comsuming {stop - start}s")
+            self.config.log(f"Loss in iteration {epoch} : {avg_loss} consuming {stop - start}s")
 
             if epoch % save_freq == 0:
                 self.save_ckpt(epoch)

--- a/tkge/task/trainer.py
+++ b/tkge/task/trainer.py
@@ -308,11 +308,8 @@ class TrainTask(Task):
         raise NotImplementedError
 
     def save_ckpt(self, epoch):
-        overall_ckpt_folder = self.config.get("train.checkpoint.folder")
-        ckpt_folder = os.path.join(overall_ckpt_folder, self.config.get("model.type"))
-        filename = f"{self.config.train_config_name(epoch)}.ckpt"
-
-        self.config.log(f"Save the model to {ckpt_folder} as file {filename}")
+        filename = f"epoch-{epoch}.ckpt"
+        self.config.log(f"Save the model to {self.config.ckpt_folder} as file {filename}")
 
         if self.lr_scheduler:
             checkpoint = {
@@ -328,10 +325,10 @@ class TrainTask(Task):
                 'optimizer': self.optimizer.state_dict()
             }
 
-        if not os.path.exists(ckpt_folder):
-            os.makedirs(ckpt_folder, 0o700)
+        if not os.path.exists(self.config.ckpt_folder):
+            os.makedirs(self.config.ckpt_folder, 0o700)
 
-        torch.save(checkpoint, os.path.join(ckpt_folder, filename))  # os.path.join(model, dataset, folder, filename))
+        torch.save(checkpoint, os.path.join(self.config.ckpt_folder, filename))  # os.path.join(model, dataset, folder, filename))
 
     def load_ckpt(self, ckpt_path):
         raise NotImplementedError


### PR DESCRIPTION
**Update Description**
- No more need of seperate logging and checkpoint directories in config file, just use console.execution_dir as overall execution folder.
- Implemented a useful directory hierarchie to maintain checkpoints and logfiles.
- A ckpt/log file will now be saved based on its **execution type** (train, eval, search, etc.), its **model type** (ttranse, ta_transe, atise, etc.), its **configuration name** (e.g. config-atise, config-default, config-ttranse-my-individual-config-name, etc.) and its **execution id** (unique identifier generated based on the biggest id in the directory, if already exists).
- The ckpt files have their **epoch numbers** in their name.
- The logfiles have their **start timestamp** in their names.
- So the hierarchy is like shown in figure 1 below
- **New configuration parameters**:
  - `log_level`: {`debug`, `info`, `warning`, `error`} --> hierarchy from left (weakest) to right (strongest)
  - `echo`: {`True`, `False`} --> whether the logs should also be printed to the console output or only to the logfile

Figure 1: Hierarchy of the experiment management 
```
execution -> execution_type -> model -> config-name -> execution_id
                                                                    -> log
                                                                            -> %Y-%m-%d-%H-%M-%S.log
                                                                    -> ckpt
                                                                            -> epoch-n.log
```

**TODO**

- [x] Implement different logging levels, i.e. DEBUG, INFO, WARNING and ERROR with their labels

**Tests**
Tested the directory creation, it works.

**Branch**
#6 